### PR TITLE
Modernize homepage layout

### DIFF
--- a/Styles.css
+++ b/Styles.css
@@ -1,161 +1,478 @@
 @font-face {
-  font-family: 'Rubik', sans-serif;
-  src: url('Fonts/Rubik/Rubik-Light.ttf') format('truetype');
-  font-weight: normal;
+  font-family: "Rubik";
+  src: url("Fonts/Rubik/Rubik-Light.ttf") format("truetype");
+  font-weight: 300;
   font-style: normal;
 }
 
+:root {
+  --bg-gradient: radial-gradient(circle at top left, #6c7bff 0%, #5533ff 25%, #1c1b29 60%, #0c0b16 100%);
+  --surface: rgba(20, 21, 40, 0.75);
+  --surface-alt: rgba(31, 32, 55, 0.8);
+  --text-primary: #f8f9ff;
+  --text-secondary: rgba(248, 249, 255, 0.72);
+  --accent: #9d8cff;
+  --accent-strong: #ff71d9;
+  --border-soft: rgba(255, 255, 255, 0.08);
+  --shadow-elevated: 0 20px 45px rgba(5, 6, 20, 0.45);
+  --max-width: min(1100px, 92vw);
+  --transition: 180ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  overflow-x: hidden;
+  margin: 0;
+  font-family: "Rubik", sans-serif;
+  color: var(--text-primary);
+  background: #090812;
+  background-image: var(--bg-gradient);
+  background-attachment: fixed;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  width: var(--max-width);
+  margin: 0 auto;
+  padding: 3rem 0 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+}
+
+.site-header {
+  background: rgba(7, 7, 15, 0.8);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-soft);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.site-nav {
+  width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  gap: 1.5rem;
+}
+
+.site-nav .brand {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--text-primary);
+  font-size: 1.1rem;
+}
+
+.nav-links {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.nav-links a {
+  color: var(--text-secondary);
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+  border: 1px solid transparent;
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible {
+  color: var(--text-primary);
+  border-color: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateY(-1px);
+}
+
+.nav-links a.active {
+  color: var(--text-primary);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border: none;
+  box-shadow: 0 10px 25px rgba(157, 140, 255, 0.35);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+  align-items: center;
+  background: var(--surface);
+  border-radius: 32px;
+  padding: 3.5rem;
+  box-shadow: var(--shadow-elevated);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 25% 20%, rgba(255, 113, 217, 0.25), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(157, 140, 255, 0.3), transparent 60%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero__content h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 3vw + 1.2rem, 3.6rem);
+  line-height: 1.05;
+}
+
+.hero__content p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 500;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: var(--text-primary);
+  box-shadow: 0 16px 40px rgba(157, 140, 255, 0.45);
+}
+
+.button.primary:hover,
+.button.primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 50px rgba(157, 140, 255, 0.55);
+}
+
+.button.ghost {
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+  backdrop-filter: blur(2px);
+}
+
+.button.ghost:hover,
+.button.ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateY(-2px);
+}
+
+.hero__media {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.hero__portrait {
+  width: clamp(220px, 40vw, 320px);
+  aspect-ratio: 1 / 1;
+  padding: 0.9rem;
+  border-radius: 32px;
+  background: var(--surface-alt);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow-elevated);
+  position: relative;
+}
+
+.hero__portrait::before,
+.hero__portrait::after {
+  content: "";
+  position: absolute;
+  border-radius: 32px;
+  inset: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+}
+
+.hero__portrait img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 24px;
+  border: none;
+  cursor: pointer;
+  transition: transform 220ms ease;
+}
+
+.hero__portrait img:hover {
+  transform: scale(1.03);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin: 0;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.info-card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 2rem;
+  border: 1px solid var(--border-soft);
+  box-shadow: 0 15px 35px rgba(5, 6, 20, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.info-card:hover,
+.info-card:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.info-card h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.info-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.cta {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: color var(--transition), transform var(--transition);
+}
+
+.cta::after {
+  content: "→";
+  transition: transform var(--transition);
+}
+
+.cta:hover,
+.cta:focus-visible {
+  color: var(--accent-strong);
+}
+
+.cta:hover::after,
+.cta:focus-visible::after {
+  transform: translateX(4px);
+}
+
+.moe-counter {
   text-align: center;
-  font-family: 'Rubik', sans-serif;
-  height: 2000px; /* Set a height for the page to enable scrolling */
+  background: var(--surface);
+  border-radius: 28px;
+  padding: 2.5rem 2rem;
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-elevated);
 }
 
-padbreak{padding:10px;}
-
-h1{
-    text-decoration: underline;
+.moe-counter h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.9rem;
 }
 
-h3{ 
-	text-decoration: underline;
+.moe-counter p {
+  margin: 0 0 1.5rem;
+  color: var(--text-secondary);
 }
+
+.counter-img {
+  width: min(260px, 100%);
+  border-radius: 999px;
+  border: none;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.5rem 1rem;
+}
+
+.gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.gallery h2 {
+  margin: 0;
+  font-size: 1.85rem;
+}
+
+.gallery__track {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(200px, 1fr);
+  gap: 1.5rem;
+  overflow-x: auto;
+  padding: 1.5rem;
+  background: var(--surface);
+  border-radius: 28px;
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-elevated);
+  scroll-snap-type: x mandatory;
+  mask-image: linear-gradient(90deg, transparent, #000 10%, #000 90%, transparent);
+}
+
+.gallery__track img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 20px;
+  border: none;
+  scroll-snap-align: center;
+  transition: transform var(--transition);
+}
+
+.gallery__track img:hover {
+  transform: translateY(-6px);
+}
+
+.site-footer {
+  margin-top: auto;
+  padding: 2rem 1rem 2.5rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+    padding: 3rem 2rem;
+  }
+
+  .hero__content {
+    align-items: center;
+  }
+
+  .hero__actions {
+    justify-content: center;
+  }
+
+  .hero__portrait {
+    margin: 0 auto;
+  }
+
+  .site-nav {
+    flex-direction: column;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 600px) {
+  main {
+    padding: 2rem 0 3rem;
+  }
+
+  .hero {
+    padding: 2.5rem 1.5rem;
+  }
+
+  .info-card {
+    padding: 1.75rem;
+  }
+
+  .gallery__track {
+    grid-auto-columns: minmax(160px, 1fr);
+    padding: 1.2rem;
+  }
+}
+
+/* Legacy utilities kept for other pages */
 img {
-  border-width: 6px;
-  border-style: solid;
-  border-color: black;
-  max-width:15%;
+  max-width: 100%;
   height: auto;
-  text-align:center;
+  border: none;
 }
 
-img.image-borderless{
-  border-width: 0px;
-  border-style: none;
-  border-color: none;
-  max-width:15%;
-  height: auto;
-  text-align:center;
+img.image-borderless {
+  border: none;
 }
 
 img.horizontal {
-  border-width: 6px;
-  border-style: solid;
-  border-color: black;
-  max-height: 30%;
-  width:auto;
-  text-align:center;
+  border: none;
 }
 
-img.Based{
-  border-width: 0px;
-  border-style: none;
-  border-color: black;
-  max-height: 40%;
-  width:auto;
-  text-align:center;
+img.Based {
+  border: none;
 }
 
 canvas {
-  border-width: 6px;
-  text-align: center;
-  border-style: solid;
-  border-color: black;
   display: block;
   margin: 0 auto;
-}
-
-nav {
-    
-  background-color: #333;
-  overflow: hidden;
-  
-}
-
-nav img {
-	max-width:15%;
-	height: auto;
-    margin-top: 8px;
-	border-width:2px;
-	
-}
-
-
-nav a {
-    
-  float: left;
-  color: white;
-  text-align: center;
-  padding: 14px 16px;
-  text-decoration: none;
-}
-
-nav a:hover {
-    
-  background-color: #ddd;
-  color: black;
-}
-
-nav a.active {
-    
-  background-color: #5533ff;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 10px 25px rgba(5, 6, 20, 0.4);
 }
 
 .grid-container {
-	display: grid;
-	grid-template-columns: repeat(6, 1fr);
-	grid-gap: 10px;
-	padding:30px;
-	background-color: var(--color-start);
-	
-	}
-.grid-item {
-	text-align: center;
-	padding:30px;
-	box-align:center;
-	}
-.grid-item img {
-	max-width: 100%;
-	height: auto;
-	text-align: center;
-	border-width:0px;
-	}
-        
-.gallery {
-	padding:30px;
-    white-space: nowrap;
-    position: relative;
-    animation: slide 32s linear infinite; 
-	}
-
-.gallery img {
-    display: inline-block;
-    max-width: 45%;
-    width: auto;
-    height: auto;
-    vertical-align: middle;
-	}
-
-.spin {
-	animation: spin 1s linear;
-	
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
 }
 
-@keyframes slide {
-	from {
-		transform: translateX(-20%);
-		}
-	to {
-		transform: translateX(-243%);
-	}
+.grid-item {
+  text-align: center;
+  padding: 1.5rem;
+}
+
+.grid-item img {
+  border: none;
+}
+
+.spin {
+  animation: spin 1.5s linear;
 }
 
 @keyframes spin {
-        0% {
-          transform: rotate(0deg);
-        }
-        100% {
-          transform: rotate(360deg);
-        }
-      }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,61 +1,110 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-	<link rel="icon" type="image/x-icon" href="favicon.png">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="favicon.png" />
     <title>32KZ</title>
-    <link rel="stylesheet" type="text/css" href="Styles.css">
+    <link rel="stylesheet" type="text/css" href="Styles.css" />
+    <meta property="og:title" content="32kzWebsite" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://32kz.github.io/32kzWebsite/" />
+    <meta property="og:locale" content="en_GB" />
+    <meta property="og:description" content="All about 32KZ, their Projects, and Services!" />
+    <meta property="og:image" content="Images/Seele.png" />
   </head>
   <body>
-    <!-- Nav Bar -->
-	<nav>
-	  <a style="display:none" id="InDev" target="_blank" href="InDevPage.html">Indev!</a>
-      <a href="index.html" class="active" >Home</a>
-	  <a href="Projects.html"  >Projects</a>
-      <a href="Services.html">Services</a>
-<a href="stupidFeed.html">Stupid Feed</a>
-	  
-    </nav>
-	<padbreak><p> </p></padbreak>
+    <header class="site-header">
+      <nav class="site-nav">
+        <a class="brand" href="index.html">32KZ</a>
+        <div class="nav-links">
+          <a style="display: none" id="InDev" target="_blank" href="InDevPage.html">Indev!</a>
+          <a href="index.html" class="active">Home</a>
+          <a href="Projects.html">Projects</a>
+          <a href="Services.html">Services</a>
+          <a href="stupidFeed.html">Stupid Feed</a>
+        </div>
+      </nav>
+    </header>
 
-    <!-- Content  -->
-	<img id="pfp" src="Images/Seele.png" alt="Profile Picture" onclick="ShowInDev()">
-    <h1>32KZ</h1>
-    <p>Welcome to my website!</p>
-    <p>this website is Full of my Code, hobbies, projects, and services!</p>
-    <p>See the <b>navigation bar</b> for all of my different projects!</p>
-	
-	<padbreak></padbreak>
-	
-	<img src="https://count.moeyy.cn/get/@:32KZ?theme=asoul" class="image-borderless" alt="32KZ Moe Counter" />
-	
-	<padbreak></padbreak>
-	
-	<div class="gallery">
-		<img src="Images/Honoji Academy.png">
-		<img src="Images/Heat Haze Daze.jpeg">
-		<img src="Images/Kagerou Team.jpeg">
-		<img src="Images/Rather-Be-Nightcore.jpg">
-		<img src="Images/Kagerou-Sky.png">
-		
-		<img src="Images/Honoji Academy.png">
-		<img src="Images/Heat Haze Daze.jpeg">
-		<img src="Images/Kagerou Team.jpeg">
-		<img src="Images/Rather-Be-Nightcore.jpg">
-		<img src="Images/Kagerou-Sky.png">
+    <main>
+      <section class="hero">
+        <div class="hero__content">
+          <p class="eyebrow">Welcome traveller 👋</p>
+          <h1>Code, hobbies, music &amp; more from 32KZ</h1>
+          <p>
+            Explore a curated mix of projects, services, and personal favorites that
+            power my creative universe.
+          </p>
+          <div class="hero__actions">
+            <a class="button primary" href="Projects.html">View projects</a>
+            <a class="button ghost" href="Services.html">Browse services</a>
+          </div>
+        </div>
+        <div class="hero__media">
+          <div class="hero__portrait">
+            <img id="pfp" src="Images/Seele.png" alt="Profile portrait" onclick="ShowInDev()" />
+          </div>
+        </div>
+      </section>
 
-	</div>
-	
-	<script src="JS/ShowInDev.js"></script>
+      <section class="info-grid" aria-label="Highlights">
+        <article class="info-card">
+          <h2>Projects hub</h2>
+          <p>
+            Dive into experiments, tools, and games that keep me learning. Each build is a
+            snapshot of what I am tinkering with right now.
+          </p>
+          <a class="cta" href="Projects.html">Go to projects</a>
+        </article>
+        <article class="info-card">
+          <h2>Services</h2>
+          <p>
+            Need a hand? I offer services ranging from coding help to creative support. Let
+            us make something awesome together.
+          </p>
+          <a class="cta" href="Services.html">See services</a>
+        </article>
+        <article class="info-card">
+          <h2>Community feed</h2>
+          <p>
+            Catch the latest updates, thoughts, and randomness in the Stupid Feed. It is
+            the best way to follow along.
+          </p>
+          <a class="cta" href="stupidFeed.html">Read the feed</a>
+        </article>
+      </section>
 
-	
-	<meta property="og:title" content="32kzWebsite" />
-	<meta property="og:type" content="website" />
-	<meta property="og:url" content="https://32kz.github.io/32kzWebsite/" />
-	<meta property="og:locale" content="en_GB" />
-	<meta property="og:description" content="All about 32KZ, their Projects, and Services!" />
-	<meta property="og:image" content="url(.Images/Seele.png)" />
-	
-	
-	</div>
+      <section class="moe-counter" aria-label="Visitor counter">
+        <h2>You're among friends</h2>
+        <p>Thanks for stopping by&mdash;here's the live visitor counter:</p>
+        <img src="https://count.moeyy.cn/get/@:32KZ?theme=asoul" class="counter-img" alt="32KZ Moe Counter" />
+      </section>
+
+      <section class="gallery" aria-label="Gallery of favorites">
+        <h2>Current inspirations</h2>
+        <div class="gallery__track">
+          <img src="Images/Honoji Academy.png" alt="Honoji Academy artwork" />
+          <img src="Images/Heat Haze Daze.jpeg" alt="Heat Haze Daze cover" />
+          <img src="Images/Kagerou Team.jpeg" alt="Kagerou Team illustration" />
+          <img src="Images/Rather-Be-Nightcore.jpg" alt="Rather Be Nightcore cover" />
+          <img src="Images/Kagerou-Sky.png" alt="Kagerou sky art" />
+          <img src="Images/Honoji Academy.png" alt="Honoji Academy artwork" />
+          <img src="Images/Heat Haze Daze.jpeg" alt="Heat Haze Daze cover" />
+          <img src="Images/Kagerou Team.jpeg" alt="Kagerou Team illustration" />
+          <img src="Images/Rather-Be-Nightcore.jpg" alt="Rather Be Nightcore cover" />
+          <img src="Images/Kagerou-Sky.png" alt="Kagerou sky art" />
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; <span id="year"></span> 32KZ. Built with passion and the assets you see here.</p>
+    </footer>
+
+    <script src="JS/ShowInDev.js"></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the homepage structure with a hero, highlights, and refreshed gallery sections
- restyle global navigation and components with a modern gradient aesthetic while keeping legacy utilities for other pages
- add a live footer year script and improved open graph metadata

## Testing
- `python3 -m http.server 8000` (manually inspected via browser screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68e507714080832c9e6cb9d6cf5ae97e